### PR TITLE
Correct bug about callback not called

### DIFF
--- a/gpio.go
+++ b/gpio.go
@@ -206,7 +206,7 @@ func (gp *GpioPin) RemoveCallback(cb Callback) {
 
 func (gp *GpioPin) invokeCallbacks(level int, tick uint) {
 	for _, cb := range gp.callbacks {
-		if int(cb.edge) == level {
+		if int(cb.edge)^level > 0 {
 			cb.fn(gp, tick)
 		}
 	}


### PR DESCRIPTION
Hi,
I've found a bug when using callbacks. 
The callback calls in gpio.go are not called because of a bad filtering.
According to the python file from pigpio, the filter should be int(cb.edge)^level > 0

Best regards